### PR TITLE
Incredibly useful fs_filter parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,76 @@ dmypy.json
 .venv/
 
 # End of https://www.gitignore.io/api/python
+
+ Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
+.idea/codeStyles
+.idea/inspectionProfiles
+

--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,7 @@ dmypy.json
 
 # End of https://www.gitignore.io/api/python
 
- Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff

--- a/jinja2_fsloader/__init__.py
+++ b/jinja2_fsloader/__init__.py
@@ -23,17 +23,21 @@ class FSLoader(jinja2.BaseLoader):
 
     >>> zip_loader = FSLoader("zip:///path/to/my/templates.zip")
     >>> ftp_loader = FSLoader(fs.ftpfs.FTPFS("server.net"))
+    >>> dir_loader = FSLoader("./templates/", fs_filter=["*.html"])
 
     Per default the template encoding is ``'utf-8'`` which can be changed
-    by setting the `encoding` parameter to something else. The `syspath`
+    by setting the `encoding` parameter to something else. The `use_syspath`
     parameter can be opted in to provide Jinja2 the system path to the query
     if it exist, otherwise it will only return the internal filesystem path.
+    The optional `fs_filter` parameter is a list of wildcard patterns like
+    ``['*.html', '*.tpl']``. If present, only the matching files in the
+    filesystem will be loaded as templates.
 
     .. seealso:: the `PyFilesystem docs <https://docs.pyfilesystem.org/>`_.
 
     """
 
-    def __init__(self, template_fs, encoding='utf-8', use_syspath=False, fs_filter=[]):
+    def __init__(self, template_fs, encoding='utf-8', use_syspath=False, fs_filter=None):
         self.filesystem = fs.open_fs(template_fs)
         self.use_syspath = use_syspath
         self.encoding = encoding

--- a/jinja2_fsloader/__init__.py
+++ b/jinja2_fsloader/__init__.py
@@ -33,10 +33,11 @@ class FSLoader(jinja2.BaseLoader):
 
     """
 
-    def __init__(self, template_fs, encoding='utf-8', use_syspath=False):
+    def __init__(self, template_fs, encoding='utf-8', use_syspath=False, fs_filter=[]):
         self.filesystem = fs.open_fs(template_fs)
         self.use_syspath = use_syspath
         self.encoding = encoding
+        self.fs_filter = fs_filter
 
     def get_source(self, environment, template):
         template = _to_unicode(template)
@@ -58,7 +59,7 @@ class FSLoader(jinja2.BaseLoader):
 
     def list_templates(self):
         found = set()
-        for file in self.filesystem.walk.files():
+        for file in self.filesystem.walk.files(filter=self.fs_filter):
             found.add(fs.path.relpath(file))
         return sorted(found)
 


### PR DESCRIPTION
I’ve added an optional fs_filter parameter which is incredibly useful: sometimes, there are other files in the `templates` folder rather than just templates. The standard Jinja2 FileSystemLoader just blindly tries to load all the files in the declared subfolder. When I use fs_filter in FSLoader, this gets passed to the Pyfilesystem2 fs.walk.files(filter), so if I specify it, I can easily get, say, just the `.html` or just the `.tpl` files in the specified folder.